### PR TITLE
Fix art mode not working sometimes

### DIFF
--- a/SamsungTvRemote/SamsungTVRemote.groovy
+++ b/SamsungTvRemote/SamsungTVRemote.groovy
@@ -626,6 +626,7 @@ def artMode() {
 		logInfo("artMode: Command not executed. Not a frameTv.")
 		return
 	}
+	getArtModeStatus()
 	def onOff = "on"
 	if (device.currentValue("artModeStatus") == "on") {
 		onOff = "off"


### PR DESCRIPTION
The art mode status gets out of sync with my TV sometimes so the art mode toggle doesn't work. Refresh the art mode status so the toggle works correctly.