### PR TITLE
Fix spurious television power on

### DIFF
--- a/SamsungTvRemote/SamsungTVRemote.groovy
+++ b/SamsungTvRemote/SamsungTVRemote.groovy
@@ -640,6 +640,9 @@ def artMode() {
 }
 
 def getArtModeStatus() {
+    if(getDataValue("frameTv") == "false") {
+    	logDebug("artMode: not retrieving status, not a frameTv.")
+    }
 	def data = [request:"get_artmode_status",
 				id: "${getDataValue("uuid")}"]
 	data = JsonOutput.toJson(data)


### PR DESCRIPTION
Due to the event driven nature of HE and this driver, there is a small chance of calling "getArtModeStatus" while the television is off.
On non-frame televisions, this will cause the tv to power on, which honestly is sometimes spooky.
I think on frame televisions this will not cause the power on, I dunno I don't have one.
The solution is simply to check if the television is a  frame tv before checking artmode status.