### PR TITLE
[Kasa EM-Multi-Plug] Tolerate "null" string for the port

### DIFF
--- a/KasaDevices/DeviceDrivers/EM-Multi-Plug.groovy
+++ b/KasaDevices/DeviceDrivers/EM-Multi-Plug.groovy
@@ -521,8 +521,11 @@ import groovy.json.JsonSlurper // library marker davegut.kasaCommunications, lin
 
 def getPort() { // library marker davegut.kasaCommunications, line 12
 	def port = 9999 // library marker davegut.kasaCommunications, line 13
-	if (getDataValue("devicePort")) { // library marker davegut.kasaCommunications, line 14
-		port = getDataValue("devicePort") // library marker davegut.kasaCommunications, line 15
+	def val = getDataValue("devicePort")
+	if (val == "null") {
+		removeDataValue("devicePort")
+	} else if (val) {
+		port = val
 	} // library marker davegut.kasaCommunications, line 16
 	return port // library marker davegut.kasaCommunications, line 17
 } // library marker davegut.kasaCommunications, line 18


### PR DESCRIPTION
Context: I have a Hubitat hub, and I've been using this package (thanks!) to control a few Kasa devices. Recently, I clicked in the package manager to update the version to the latest one (probably installed this last year) and did a re-scan to add a few devices.

After those steps, I noticed the multi-plug strip stopped answering commands (on/off).

Doing some debugging, it turned out that the string "null" (the STRING, not the null value) got saved under the deviceData. This is likely a bug in the discovery app that I haven't looked at further. Probably converts null to "null" somewhere.

However, once this null string has been added, it breaks the code as the HubAction tries to send a udp packet to "\<ip address of plug\>:null". The Hub's API sucks here and provides no error code/exception, but obviously the udp packet goes nowhere.

This just adds a check to the driver code to wipe & ignore the value if it's this "null" string

I have no idea what's going in this repository with all "// library marker" comments (or the Hubitat things in general, this is the first time I look at any Driver's code), the files look like the output of some preprocessing you run before committing them? Feel free to fix this yourself in the original files, and please consider committing the source files + the build system. :)