### PR TITLE
#29: KasaDevices - Fix issue with auth failure

### DIFF
--- a/KasaDevices/Application/KasaIntegrationApp.groovy
+++ b/KasaDevices/Application/KasaIntegrationApp.groovy
@@ -474,7 +474,7 @@ def getToken() {
 		params: [
 			appType: "Kasa_Android",
 			cloudUserName: "${userName}",
-			cloudPassword: "${userPassword}",
+			cloudPassword: "${userPassword}.replaceAll('&gt;', '>').replaceAll('&lt;','<')",
 			terminalUUID: "${termId}"]]
 	cmdData = [uri: "https://wap.tplinkcloud.com",
 			   cmdBody: cmdBody]


### PR DESCRIPTION
Hubitat escapes input that has certain special characters. This needs to be reversed before sending passwords.
(This may not be exactly correct and there maybe other characters needed for this as well, but this patch resolved the issue I encountered.)